### PR TITLE
auto-removes spotlight when typing or not using the mouse

### DIFF
--- a/MouseSpotlight.ahk
+++ b/MouseSpotlight.ahk
@@ -3,6 +3,7 @@
 #NoEnv
 #MaxThreadsPerHotkey 3
 #installmousehook
+#installkeybdhook
 #MaxHotkeysPerInterval 100
 
 SetBatchLines, -1
@@ -12,11 +13,66 @@ SetWorkingDir, %A_ScriptDir%
 
 ClickEvents := []
 
+; Variables for the new spotlight behavior
+SpotlightCurrentlyTyping := False
+SpotlightLastMouseX := -1
+SpotlightLastMouseY := -1
+SpotlightMouseHasMovedSinceTyping := False
+SpotlightShouldShowBasedOnActivity := True
+
 SetupMouseSpotlight()
 {
     global
     SETTINGS := ReadConfigFile("settings.ini")
     InitializeSpotlightGUI()
+    SetupKeyboardHooksForSpotlight()
+}
+
+SetupKeyboardHooksForSpotlight()
+{
+    global
+    ; Hook all keyboard keys to detect typing
+    ProcessKeyForSpotlightFunc := Func("ProcessKeyForSpotlight")
+    SetFormat, Integer, hex
+    start := 0 
+    Loop, 227
+    {
+        if ((key := GetKeyName("vk" start++)) != "")
+            Hotkey, ~*%key%, %ProcessKeyForSpotlightFunc%
+    }
+    
+    ; Add special keys
+    for a, b in StrSplit("Up,Down,Left,Right,End,Home,PgUp,PgDn,Insert,Delete,NumpadEnter,Space,Tab,Enter,Backspace",",")
+    {
+        Hotkey, ~*%b%, %ProcessKeyForSpotlightFunc%
+    }
+    SetFormat, Integer, dec
+}
+
+ProcessKeyForSpotlight()
+{
+    global SpotlightCurrentlyTyping, SpotlightMouseHasMovedSinceTyping, SpotlightShouldShowBasedOnActivity
+    
+    ; Skip modifier keys (we only want to detect actual typing)
+    theKeyPressed := SubStr(A_ThisHotkey, 3)
+    if (theKeyPressed == "LShift" || theKeyPressed == "RShift" || theKeyPressed == "LControl" || theKeyPressed == "RControl" 
+        || theKeyPressed == "LAlt" || theKeyPressed == "RAlt" || theKeyPressed == "LWin" || theKeyPressed == "RWin")
+    {
+        Return
+    }
+    
+    ; User started typing - hide spotlight
+    SpotlightCurrentlyTyping := True
+    SpotlightMouseHasMovedSinceTyping := False
+    SpotlightShouldShowBasedOnActivity := False
+    
+    ; Reset typing state after 1 second of no typing
+    SetTimer, ResetTypingState, -1000
+    Return
+    
+    ResetTypingState:
+        SpotlightCurrentlyTyping := False
+    Return
 }
 
 InitializeSpotlightGUI(){ 
@@ -45,17 +101,55 @@ InitializeSpotlightGUI(){
             ; SETTINGS.cursorSpotlight.enabled can be changed by other script such as Annotation.ahk
             if (SETTINGS.cursorSpotlight.enabled == True)
             {
-                MouseGetPos, X, Y
-                X -= CursorSpotlightDiameter / 2
-                Y -= CursorSpotlightDiameter / 2
-                WinMove, ahk_id %CursorSpotlightHwnd%, , %X%, %Y%
-                WinSet, AlwaysOnTop, On, ahk_id %CursorSpotlightHwnd%
+                MouseGetPos, CurrentX, CurrentY
+                
+                ; Check if mouse has moved
+                if (SpotlightLastMouseX != CurrentX || SpotlightLastMouseY != CurrentY)
+                {
+                    ; Mouse moved - reset typing flag and show spotlight
+                    if (SpotlightCurrentlyTyping)
+                    {
+                        SpotlightMouseHasMovedSinceTyping := True
+                        SpotlightShouldShowBasedOnActivity := True
+                    }
+                    else
+                    {
+                        SpotlightShouldShowBasedOnActivity := True
+                    }
+                    
+                    SpotlightLastMouseX := CurrentX
+                    SpotlightLastMouseY := CurrentY
+                    
+                    ; Reset the auto-hide timer (2 seconds after mouse stops moving)
+                    SetTimer, HideSpotlightAfterInactivity, -2000
+                }
+                
+                ; Show spotlight only if: not currently typing (or mouse moved since typing) AND activity-based showing is enabled
+                shouldShowSpotlight := SpotlightShouldShowBasedOnActivity && (!SpotlightCurrentlyTyping || SpotlightMouseHasMovedSinceTyping)
+                
+                if (shouldShowSpotlight)
+                {
+                    X := CurrentX - CursorSpotlightDiameter / 2
+                    Y := CurrentY - CursorSpotlightDiameter / 2
+                    WinMove, ahk_id %CursorSpotlightHwnd%, , %X%, %Y%
+                    WinSet, AlwaysOnTop, On, ahk_id %CursorSpotlightHwnd%
+                }
+                else
+                {
+                    ; Hide spotlight by moving it off screen
+                    WinMove, ahk_id %CursorSpotlightHwnd%, , -999999999, -999999999
+                }
             }
             else
             {
                  WinMove, ahk_id %CursorSpotlightHwnd%, , -999999999, -999999999
             }
 
+        Return
+        
+        HideSpotlightAfterInactivity:
+            ; Hide spotlight after 2 seconds of no mouse movement
+            SpotlightShouldShowBasedOnActivity := False
         Return
     }
 }


### PR DESCRIPTION
I asked Claude AI to add this feature:


I'll modify the `MouseSpotlight.ahk` script to add the new feature. This will turn off the highlight when typing, turn it back on when moving the mouse, and automatically hide it after 2 seconds of no mouse movement.


Perfect! I've successfully added the new feature to `MouseSpotlight.ahk`. Here's what the implementation does:

## New Features Added:

### 1. **Hide spotlight when typing**
- Hooks all keyboard keys to detect when you start typing
- Immediately hides the spotlight when any non-modifier key is pressed
- Ignores modifier keys (Shift, Ctrl, Alt, Win) so they don't trigger hiding

### 2. **Show spotlight when moving mouse** 
- Tracks mouse movement continuously
- When mouse moves after typing, the spotlight reappears immediately
- Works even if you're still in "typing mode"

### 3. **Auto-hide after 2 seconds of inactivity**
- Starts a 2-second timer whenever the mouse stops moving
- Automatically hides the spotlight after 2 seconds of no mouse movement
- Timer resets each time you move the mouse

## How it works:

1. **Typing Detection**: Uses keyboard hooks to detect actual typing (excluding modifier keys)
2. **Mouse Movement Tracking**: Compares current mouse position with previous position each frame
3. **Smart State Management**: 
   - `SpotlightCurrentlyTyping` - tracks typing state
   - `SpotlightMouseHasMovedSinceTyping` - allows spotlight to show even while typing if mouse moved
   - `SpotlightShouldShowBasedOnActivity` - controls the 2-second auto-hide feature

4. **Timing**:
   - Typing state resets after 1 second of no typing
   - Auto-hide triggers after 2 seconds of no mouse movement

The feature integrates seamlessly with existing functionality - other scripts can still control the spotlight via `SETTINGS.cursorSpotlight.enabled`, and all original behavior is preserved. The spotlight will now feel much more responsive to your actual activity!